### PR TITLE
Add full encoder control and Vuforia Skytone detection

### DIFF
--- a/AutoOp.java
+++ b/AutoOp.java
@@ -42,7 +42,7 @@ public abstract class AutoOp extends LinearOpMode {
     private double armStatic = 0.3;
     protected double wheelPower = 0.8;
     private double margin = 1;
-    private double ticksPerTile = 1120/4/3.141592653589793238462643383279502884*24*(4.0/3.0); // 1120 ticks/rev * 1/4pi rev/in * 24 in/tile * gear_ratio
+    private double ticksPerTile = 1120/4/3.141592653589793238462643383279502884*24*1.0; // 1120 ticks/rev * 1/4pi rev/in * 24 in/tile * gear_ratio
     private double turningCorrection = 0.001;
     
     /** Initialization **/
@@ -315,6 +315,7 @@ public abstract class AutoOp extends LinearOpMode {
         }
         stopWheels();
     }
+    @Deprecated
     public void right_time(double quarters){
         leftWheels(wheelPower);
         rightWheels(-wheelPower);

--- a/AutoOp.java
+++ b/AutoOp.java
@@ -34,6 +34,7 @@ public abstract class AutoOp extends LinearOpMode {
     private Telemetry telemetry_ = null;
     
     private double speed = 0.55*1.4;
+    private double quit_speed = 2.0;
     private double strafe_spd = 1.2;
     private double turn90 = 0.73;//73, 75
     private double armSpd = 0.5;
@@ -149,10 +150,7 @@ public abstract class AutoOp extends LinearOpMode {
     
     /** Encoder-Based Movement **/
     public void move(double y_tiles, double x_tiles, String name){
-        leftfront.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
-        leftback.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
-        rightfront.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
-        rightback.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        resetWheels();
         leftfront.setTargetPosition((int) ((y_tiles+x_tiles)*ticksPerTile));
         leftback.setTargetPosition((int) ((y_tiles-x_tiles)*ticksPerTile));
         rightfront.setTargetPosition((int) ((y_tiles-x_tiles)*ticksPerTile));
@@ -165,7 +163,8 @@ public abstract class AutoOp extends LinearOpMode {
         leftback.setPower(wheelPower);
         rightfront.setPower(wheelPower);
         rightback.setPower(wheelPower);
-        while(opModeIsActive() && (leftfront.isBusy() || rightfront.isBusy() || leftback.isBusy() || rightback.isBusy())){
+        runtime.reset();
+        while(opModeIsActive() && (leftfront.isBusy() || rightfront.isBusy() || leftback.isBusy() || rightback.isBusy()) && runtime.seconds() < Math.sqrt(y_tiles*y_tiles+x_tiles*x_tiles)*quit_speed){
             telemetry_.addData("Path", "%s: %s lf, %s rf, %s lb, %s rb", name, leftfront.getCurrentPosition(), rightfront.getCurrentPosition(), leftback.getCurrentPosition(), rightback.getCurrentPosition());
             telemetry_.update();
         }
@@ -192,6 +191,24 @@ public abstract class AutoOp extends LinearOpMode {
     }
     public void backward_enc(double tiles){
         move(-tiles, 0.0, "Backward");
+    }
+    
+    /** Encoder Utilities **/
+    public void resetWheels(){
+        leftfront.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        leftback.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        rightfront.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        rightback.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+    }
+    public double[] getVector(){
+        double[] offset = new double[2];
+        double lf = leftfront.getCurrentPosition() / ticksPerTile;
+        double lb = leftback.getCurrentPosition() / ticksPerTile;
+        double rf = rightfront.getCurrentPosition() / ticksPerTile;
+        double rb = rightback.getCurrentPosition() / ticksPerTile;
+        offset[0] = (lf + lb + rf + rb) / 4;
+        offset[1] = (lf + lb + rf + rb) / 4;
+        return offset;
     }
     
     /** Gyroscope-Based Rotation **/
@@ -364,7 +381,7 @@ public abstract class AutoOp extends LinearOpMode {
         }
     }
     public void fingerDown(){
-        finger1.setPosition(0.9);
+        finger1.setPosition(0.85);
         finger2.setPosition(0.1);
         runtime.reset();
         while(opModeIsActive() && runtime.seconds() < 0.4){

--- a/AutoOp.java
+++ b/AutoOp.java
@@ -37,11 +37,11 @@ public abstract class AutoOp extends LinearOpMode {
     private double strafe_spd = 1.2;
     private double turn90 = 0.73;//73, 75
     private double armSpd = 0.5;
-    private double armPower = 0.3;
-    private double armStatic = 0.02;
-    protected double wheelPower = 0.75;
+    private double armPower = 0.25;
+    private double armStatic = 0.3;
+    protected double wheelPower = 0.8;
     private double margin = 1;
-    private double ticksPerTile = 1120/4/3.141592653589793238462643383279502884*24; // 1120 ticks/rev * 1/4pi rev/in * 24 in/tile
+    private double ticksPerTile = 1120/4/3.141592653589793238462643383279502884*24*(4.0/3.0); // 1120 ticks/rev * 1/4pi rev/in * 24 in/tile * gear_ratio
     private double strafeTraction = 0.9;
     private double turningCorrection = 0.001;
     
@@ -90,9 +90,8 @@ public abstract class AutoOp extends LinearOpMode {
         return (angles.firstAngle - zero_heading + 360) % 360.0 - 180.0;
     }
     
+    @Deprecated
     public void zeroHeading(){
-        //double off = getAngle();
-        //zero_heading += off;
         angles = imu.getAngularOrientation(AxesReference.INTRINSIC, AxesOrder.ZYX, AngleUnit.DEGREES);
         zero_heading = angles.firstAngle;
     }
@@ -147,10 +146,10 @@ public abstract class AutoOp extends LinearOpMode {
         rightback.setPower(spd-corr);
     }
     public void strafeRightSpd(double spd){
-        strafeRightSpd(spdl, 0.0);
+        strafeRightSpd(spd, 0.0);
     }
     
-    public void strafeLeft(double tiles){
+    public void strafeLeft_time(double tiles){
         zeroHeading();
         strafeLeftSpd(wheelPower);
         runtime.reset();
@@ -160,8 +159,46 @@ public abstract class AutoOp extends LinearOpMode {
         }
         stopWheels();
     }
+    public void strafeLeft_enc(double tiles){
+        leftfront.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        leftback.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        rightfront.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        rightback.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        leftfront.setTargetPosition((int) (-tiles*ticksPerTile));
+        leftback.setTargetPosition((int) (tiles*ticksPerTile));
+        rightfront.setTargetPosition((int) (tiles*ticksPerTile));
+        rightback.setTargetPosition((int) (-tiles*ticksPerTile));
+        leftfront.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+        leftback.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+        rightfront.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+        rightback.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+        leftfront.setPower(wheelPower);
+        leftback.setPower(wheelPower);
+        rightfront.setPower(wheelPower);
+        rightback.setPower(wheelPower);
+        /*while(opModeIsActive() && leftback.isBusy()){  // If the front two wheels are still running, the robot will continue straight
+            telemetry_.addData("Path", "Forward: %s lf, %s rf, %s lb", leftfront.getCurrentPosition(), rightfront.getCurrentPosition(), leftback.getCurrentPosition());
+            telemetry_.update();
+        }*/
+        //rightback.setPower(0.0);
+        while(opModeIsActive() && (leftfront.isBusy() || rightfront.isBusy() || leftback.isBusy() || rightback.isBusy())){
+            telemetry_.addData("Path", "Forward: %s lf, %s rf, %s lb, %s rb", leftfront.getCurrentPosition(), rightfront.getCurrentPosition(), leftback.getCurrentPosition(), rightback.getCurrentPosition());
+            telemetry_.update();
+        }
+        leftfront.setPower(0.0);
+        leftback.setPower(0.0);
+        rightfront.setPower(0.0);
+        rightback.setPower(0.0);
+        leftfront.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        leftback.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        rightfront.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        rightback.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+    }
+    public void strafeLeft(double tiles){
+        strafeLeft_enc(tiles);
+    }
     
-    public void strafeRight(double tiles){
+    public void strafeRight_time(double tiles){
         zeroHeading();
         strafeRightSpd(wheelPower);
         runtime.reset();
@@ -170,6 +207,39 @@ public abstract class AutoOp extends LinearOpMode {
             strafeRightSpd(wheelPower, getSmAngle()*turningCorrection);
         }
         stopWheels();
+    }
+    public void strafeRight_enc(double tiles){
+        leftfront.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        leftback.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        rightfront.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        rightback.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        leftfront.setTargetPosition((int) (tiles*ticksPerTile));
+        leftback.setTargetPosition((int) (-tiles*ticksPerTile));
+        rightfront.setTargetPosition((int) (-tiles*ticksPerTile));
+        rightback.setTargetPosition((int) (tiles*ticksPerTile));
+        leftfront.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+        leftback.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+        rightfront.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+        rightback.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+        leftfront.setPower(wheelPower);
+        leftback.setPower(wheelPower);
+        rightfront.setPower(wheelPower);
+        rightback.setPower(wheelPower);
+        while(opModeIsActive() && (leftfront.isBusy() || rightfront.isBusy() || leftback.isBusy() || rightback.isBusy())){
+            telemetry_.addData("Path", "Forward: %s lf, %s rf, %s lb, %s rb", leftfront.getCurrentPosition(), rightfront.getCurrentPosition(), leftback.getCurrentPosition(), rightback.getCurrentPosition());
+            telemetry_.update();
+        }
+        leftfront.setPower(0.0);
+        leftback.setPower(0.0);
+        rightfront.setPower(0.0);
+        rightback.setPower(0.0);
+        leftfront.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        leftback.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        rightfront.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        rightback.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+    }
+    public void strafeRight(double tiles){
+        strafeRight_enc(tiles);
     }
     
     public void forward_time(double tiles){
@@ -186,27 +256,41 @@ public abstract class AutoOp extends LinearOpMode {
         leftfront.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
         leftback.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
         rightfront.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
-        leftfront.setTargetPosition(tiles*ticksPerTile);
-        leftback.setTargetPosition(tiles*ticksPerTile);
-        rightfront.setTargetPosition(tiles*ticksPerTile);
+        rightback.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        leftfront.setTargetPosition((int) (tiles*ticksPerTile));
+        leftback.setTargetPosition((int) (tiles*ticksPerTile));
+        rightfront.setTargetPosition((int) (tiles*ticksPerTile));
+        rightback.setTargetPosition((int) (tiles*ticksPerTile));
+        leftfront.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+        leftback.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+        rightfront.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+        rightback.setMode(DcMotor.RunMode.RUN_TO_POSITION);
         leftfront.setPower(wheelPower);
         leftback.setPower(wheelPower);
         rightfront.setPower(wheelPower);
         rightback.setPower(wheelPower);
-        while(opModeIsActive() && leftback.isBusy()){  // If the front two wheels are still running, the robot will continue straight
+        /*while(opModeIsActive() && leftback.isBusy()){  // If the front two wheels are still running, the robot will continue straight
             telemetry_.addData("Path", "Forward: %s lf, %s rf, %s lb", leftfront.getCurrentPosition(), rightfront.getCurrentPosition(), leftback.getCurrentPosition());
             telemetry_.update();
+        }*/
+        //rightback.setPower(0.0);
+        while(opModeIsActive() && (leftfront.isBusy() || rightfront.isBusy() || leftback.isBusy() || rightback.isBusy())){
+            telemetry_.addData("Path", "Forward: %s lf, %s rf, %s lb, %s rb", leftfront.getCurrentPosition(), rightfront.getCurrentPosition(), leftback.getCurrentPosition(), rightback.getCurrentPosition());
+            telemetry_.update();
         }
+        leftfront.setPower(0.0);
+        leftback.setPower(0.0);
+        rightfront.setPower(0.0);
         rightback.setPower(0.0);
-        while(opModeIsActive() && (leftfront.isBusy() || rightfront.isBusy())){
-            telemetry_.addData("Path", "Forward: %s lf, %s rf, %s lb", leftfront.getCurrentPosition(), rightfront.getCurrentPosition(), leftback.getCurrentPosition());
-            telemetry_.update();
-        }
+        leftfront.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        leftback.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        rightfront.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        rightback.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
     }
     public void forward(double tiles){
         forward_enc(tiles);
     }
-    public void backward(double tiles){
+    public void backward_time(double tiles){
         leftWheels(-wheelPower);
         rightWheels(-wheelPower);
         runtime.reset();
@@ -215,6 +299,39 @@ public abstract class AutoOp extends LinearOpMode {
             telemetry_.update();
         }
         stopWheels();
+    }
+    public void backward_enc(double tiles){
+        leftfront.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        leftback.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        rightfront.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        rightback.setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        leftfront.setTargetPosition((int) (-tiles*ticksPerTile));
+        leftback.setTargetPosition((int) (-tiles*ticksPerTile));
+        rightfront.setTargetPosition((int) (-tiles*ticksPerTile));
+        rightback.setTargetPosition((int) (-tiles*ticksPerTile));
+        leftfront.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+        leftback.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+        rightfront.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+        rightback.setMode(DcMotor.RunMode.RUN_TO_POSITION);
+        leftfront.setPower(wheelPower);
+        leftback.setPower(wheelPower);
+        rightfront.setPower(wheelPower);
+        rightback.setPower(wheelPower);
+        while(opModeIsActive() && (leftfront.isBusy() || rightfront.isBusy() || leftback.isBusy() || rightback.isBusy())){
+            telemetry_.addData("Path", "Forward: %s lf, %s rf, %s lb, %s rb", leftfront.getCurrentPosition(), rightfront.getCurrentPosition(), leftback.getCurrentPosition(), rightback.getCurrentPosition());
+            telemetry_.update();
+        }
+        leftfront.setPower(0.0);
+        leftback.setPower(0.0);
+        rightfront.setPower(0.0);
+        rightback.setPower(0.0);
+        leftfront.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        leftback.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        rightfront.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        rightback.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+    }
+    public void backward(double tiles){
+        backward_enc(tiles);
     }
     public void left_time(double quarters){
         leftWheels(-wheelPower);
@@ -231,25 +348,14 @@ public abstract class AutoOp extends LinearOpMode {
             quarters -= left_gyro(quarters-2);
         }
         double a = 0.0;
-        /*runtime.reset();
-        while(opModeIsActive() && runtime.seconds() < 0.5){
-            telemetry_.addData("Path", "Turning Left");
-            telemetry_.update();
-        }*/
-        zeroHeading();
-        leftWheels(-wheelPower*0.4);
-        rightWheels(wheelPower*0.4);
+        //zeroHeading();
+        leftWheels(-wheelPower);
+        rightWheels(wheelPower);
         runtime.reset();
         while(opModeIsActive() && ((a=getAngle()) < 90*quarters+margin)){
             telemetry_.addData("Path", "Turning Left: %2.5f S Elapsed, %2.3f deg", runtime.seconds(), a);
             telemetry_.update();
         }
-        /*leftWheels(0);
-        rightWheels(0);
-        while(opModeIsActive() && runtime.seconds() < 1.5){
-            telemetry_.addData("Path", "Turning Left: %2.5f S Elapsed, %2.3f deg", runtime.seconds(), a);
-            telemetry_.update();
-        }*/
         leftWheels(wheelPower*0.2);
         rightWheels(-wheelPower*0.2);
         while(opModeIsActive() && ((a=getAngle()) > 90*quarters+margin)){
@@ -258,12 +364,10 @@ public abstract class AutoOp extends LinearOpMode {
         }
         stopWheels();
         runtime.reset();
-        /*while(opModeIsActive() && runtime.seconds() < 2.0){
-            telemetry_.addData("Path", "Turning Left: %2.3f deg", a);
-            telemetry_.update();
-        }*/
+        zero_heading = (zero_heading + 90.0) % 360.0;
         return quarters;
     }
+    
     
     public void left(double quarters){
         left_gyro(quarters);
@@ -275,25 +379,14 @@ public abstract class AutoOp extends LinearOpMode {
             quarters -= 2;
         }
         double a = 0.0;
-        /*runtime.reset();
-        while(opModeIsActive() && runtime.seconds() < 0.75){
-            telemetry_.addData("Turn", "Turning Right");
-            telemetry_.update();
-        }*/
-        zeroHeading();
-        leftWheels(wheelPower*0.4);
-        rightWheels(-wheelPower*0.4);
+        //zeroHeading();
+        leftWheels(wheelPower);
+        rightWheels(-wheelPower);
         runtime.reset();
         while(opModeIsActive() && ((a=getNegAngle()) > -90*quarters-margin)){
             telemetry_.addData("Path", "Turning Right: %2.5f S Elapsed, %2.3f deg", runtime.seconds(), a);
             telemetry_.update();
         }
-        /*leftWheels(0);
-        rightWheels(0);
-        while(opModeIsActive() && runtime.seconds() < 1.5){
-            telemetry_.addData("Path", "Turning Right: %2.5f S Elapsed, %2.3f deg", runtime.seconds(), a);
-            telemetry_.update();
-        }*/
         leftWheels(-wheelPower*0.2);
         rightWheels(wheelPower*0.2);
         while(opModeIsActive() && ((a=getNegAngle()) < -90*quarters-margin)){
@@ -302,10 +395,7 @@ public abstract class AutoOp extends LinearOpMode {
         }
         stopWheels();
         runtime.reset();
-        /*while(opModeIsActive() && runtime.seconds() < 2.0){
-            telemetry_.addData("Path", "Turning Left: %2.3f deg", a);
-            telemetry_.update();
-        }*/
+        zero_heading = (zero_heading - 90.0) % 360.0;
     }
     public void right_time(double quarters){
         leftWheels(wheelPower);
@@ -347,16 +437,36 @@ public abstract class AutoOp extends LinearOpMode {
     public void fingerUp(){
         finger1.setPosition(0.0);
         finger2.setPosition(1.0);
+        runtime.reset();
+        while(opModeIsActive() && runtime.seconds() < 0.4){
+            telemetry_.addData("Path", "Opening Fingers: %2.3f S elapsed", runtime.seconds());
+            telemetry_.update();
+        }
     }
     public void fingerDown(){
         finger1.setPosition(0.9);
         finger2.setPosition(0.1);
+        runtime.reset();
+        while(opModeIsActive() && runtime.seconds() < 0.4){
+            telemetry_.addData("Path", "Closing Fingers: %2.3f S elapsed", runtime.seconds());
+            telemetry_.update();
+        }
     }
     public void openClaw(){
         claw.setPosition(1.0);
+        runtime.reset();
+        while(opModeIsActive() && runtime.seconds() < 0.5){
+            telemetry_.addData("Path", "Opening Claw: %2.3f S elapsed", runtime.seconds());
+            telemetry_.update();
+        }
     }
     public void closeClaw(){
         claw.setPosition(0.3);
+        runtime.reset();
+        while(opModeIsActive() && runtime.seconds() < 0.5){
+            telemetry_.addData("Path", "Closing Claw: %2.3f S elapsed", runtime.seconds());
+            telemetry_.update();
+        }
     }
     public void modelXUp(){
         modelX.setPower(0.5);

--- a/VisionTest.java
+++ b/VisionTest.java
@@ -1,0 +1,31 @@
+package workspace;
+
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.util.ElapsedTime;
+
+@Autonomous(name="Vision Test", group="Linear OpMode")
+
+public class VisionTest extends VuforiaOp{
+    @Override
+    public void runOpMode(){
+        ElapsedTime runtime = new ElapsedTime();
+        initVision(hardwareMap);
+        initialize(hardwareMap, telemetry);
+        activateVision();
+        telemetry.addData("Status", "waiting");
+        waitForStart();
+        runtime.reset();
+        while(opModeIsActive()){
+            calcOffset();
+            if(raw_offset == null){
+                telemetry.addData("Reading", "(%.2f S) null", runtime.seconds());
+                strafeLeftSpd(0.1);
+            }
+            else{
+                telemetry.addData("Reading", "(%.2f S) x: %.0f, y: %.0f, z: %.0f", runtime.seconds(), red_off, blue_off, green_off);
+                strafeRightSpd(red_off/1000);
+            }
+            telemetry.update();
+        }
+    }
+}

--- a/VuforiaOp.java
+++ b/VuforiaOp.java
@@ -1,0 +1,58 @@
+package workspace;
+
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+import org.firstinspires.ftc.robotcore.external.navigation.VuforiaLocalizer;
+import org.firstinspires.ftc.robotcore.external.navigation.VuforiaTrackables;
+import org.firstinspires.ftc.robotcore.external.navigation.VuforiaTrackable;
+import org.firstinspires.ftc.robotcore.external.navigation.VuforiaTrackableDefaultListener;
+import org.firstinspires.ftc.robotcore.external.matrices.OpenGLMatrix;
+import org.firstinspires.ftc.robotcore.external.ClassFactory;
+import org.firstinspires.ftc.robotcore.external.navigation.Orientation;
+import org.firstinspires.ftc.robotcore.external.navigation.AxesReference;
+import org.firstinspires.ftc.robotcore.external.navigation.AxesOrder;
+import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
+
+@Autonomous
+
+public abstract class VuforiaOp extends AutoOp {
+    private VuforiaLocalizer localizer;
+    private VuforiaLocalizer.Parameters params;
+    private VuforiaTrackables visionTargets;
+    private VuforiaTrackable target;
+    private VuforiaTrackableDefaultListener listener;
+    
+    protected OpenGLMatrix lastKnownLocation;
+    protected OpenGLMatrix phoneLocation;
+    
+    protected static final String VUFORIA_KEY = "";
+    
+    public void initVision(HardwareMap hardwareMap){
+        int cameraMonitorViewId = hardwareMap.appContext.getResources().getIdentifier("cameraMonitorViewId", "id", hardwareMap.appContext.getPackageName());
+        params = new VuforiaLocalizer.Parameters(cameraMonitorViewId);
+        params.vuforiaLicenseKey = VUFORIA_KEY;
+        params.cameraDirection = VuforiaLocalizer.CameraDirection.BACK;
+        localizer = ClassFactory.createVuforiaLocalizer(params);
+        visionTargets = localizer.loadTrackablesFromAsset("Skystone");
+        target = visionTargets.get(0);
+        target.setName("skystone");
+        target.setLocation(createMatrix(0, 0, 0, 0, 0, 0));
+        phoneLocation = createMatrix(0, 0, 0, 0, 0, 0);
+        listener = (VuforiaTrackableDefaultListener) target.getListener();
+        listener.setPhoneInformation(phoneLocation, params.cameraDirection);
+        lastKnownLocation = createMatrix(0, 0, 0, 0, 0, 0);
+        visionTargets.activate();
+    }
+    
+    public OpenGLMatrix createMatrix(float x, float y, float z, float u, float v, float w){
+        return OpenGLMatrix.translation(x, y, z)
+            .multiplied(Orientation.getRotationMatrix(
+                AxesReference.EXTRINSIC, AxesOrder.XYZ, AngleUnit.DEGREES, u, v, w));
+    }
+    
+    public float[] getOffset(){
+        OpenGLMatrix latestLocation = null;
+        float[] r = {0, 0};
+        return r;
+    }
+}

--- a/VuforiaOp.java
+++ b/VuforiaOp.java
@@ -36,7 +36,7 @@ public abstract class VuforiaOp extends AutoOp {
         int cameraMonitorViewId = hardwareMap.appContext.getResources().getIdentifier("cameraMonitorViewId", "id", hardwareMap.appContext.getPackageName());
         params = new VuforiaLocalizer.Parameters(cameraMonitorViewId);
         params.vuforiaLicenseKey = VUFORIA_KEY;
-        params.cameraDirection = VuforiaLocalizer.CameraDirection.BACK;
+        params.cameraName = hardwareMap.get(WebcamName.class, "Webcam1");
         localizer = ClassFactory.createVuforiaLocalizer(params);
         visionTargets = localizer.loadTrackablesFromAsset("Skystone");
         target = visionTargets.get(0);

--- a/VuforiaOp.java
+++ b/VuforiaOp.java
@@ -31,13 +31,15 @@ public abstract class VuforiaOp extends AutoOp {
     public double green_off;  // z; skystones should start on the ground.
     public float[] raw_offset;  // green, red, blue; zxy
     
+    private double cam_x, cam_y, cam_z;
+    
     protected static final String VUFORIA_KEY = "AeTCFCP/////AAABmfHb70GlwET4rTC9SGWFDMVfC6cZN+OykKIBJrcpYIVTGzbWZ11w8AoTq6mrdM68JbbKzA3C/+v46Jo8+pcraqzQ5QPOv23oHfxgDMKAlbxYGixALMMcSsE8Anv2NeBhMd+zLoRTYAnU8YQ7S35RYmeFRufFLUHF+Tkps1tZoWOxd6yyzuw10nwVVlZ1F4JhHVEHXoFsvUDXVxHENaFOxcy244tY+AM/qM4U9jD1RXLMPrp+ZLWmG/Bt8ja1avZHE0EWK5DKaKD0uWrT9A9WwT8w+aNjNxJKOdL9mq/fhZwDRPS6Q7flBwIQvVbq6bTXl4erMprFkPXo4yaZJvJo8ag+V5mEVe/cQ2N0A7qNtb3f";
     
     public void initVision(HardwareMap hardwareMap){
         int cameraMonitorViewId = hardwareMap.appContext.getResources().getIdentifier("cameraMonitorViewId", "id", hardwareMap.appContext.getPackageName());
         params = new VuforiaLocalizer.Parameters(cameraMonitorViewId);
         params.vuforiaLicenseKey = VUFORIA_KEY;
-        //params.cameraName = hardwareMap.get(WebcamName.class, "Webcam 1");
+        params.cameraName = hardwareMap.get(WebcamName.class, "Webcam 1");
         params.cameraDirection = VuforiaLocalizer.CameraDirection.BACK;
         localizer = ClassFactory.createVuforiaLocalizer(params);
         visionTargets = localizer.loadTrackablesFromAsset("Skystone");
@@ -52,35 +54,36 @@ public abstract class VuforiaOp extends AutoOp {
         red_off = 0;
         blue_off = 0;
         raw_offset = null;
+        setPhonePosition(0, 0, 0);
     }
     
     public void activateVision(){
         visionTargets.activate();
     }
     
-    /*public OpenGLMatrix createMatrix(float x, float y, float z, float u, float v, float w){
+    private OpenGLMatrix createMatrix(float x, float y, float z, float u, float v, float w){
         return OpenGLMatrix.translation(x, y, z)
             .multiplied(Orientation.getRotationMatrix(
                 AxesReference.EXTRINSIC, AxesOrder.XYZ, AngleUnit.DEGREES, u, v, w));
-    }*/
+    }
     
     public void calcOffset(){
-        OpenGLMatrix pose = listener.getPose();
+        OpenGLMatrix pose = null;
+        pose = listener.getFtcCameraFromTarget();//getPose();
         if(pose == null){
             raw_offset = null;
             return;
         }
         VectorF trans = pose.getTranslation();
-        float[] off = {trans.get(0), trans.get(1), trans.get(2)};
+        float[] off = /*{0,0,0};*/{trans.get(0), trans.get(1), trans.get(2)};
         // smooth the readings
-        green_off = 0.9*green_off + 0.1*off[0];
-        red_off = 0.9*red_off + 0.1*off[1];
-        blue_off = 0.9*blue_off + 0.1*off[2];
+        green_off = 0.9*green_off + 0.1*(off[0]+cam_z);
+        red_off = 0.9*red_off + 0.1*(off[1]-cam_x);
+        blue_off = 0.9*blue_off + 0.1*(off[2]-cam_y);
         raw_offset = off;
     }
     
     public void toSkystone(double threshold, double nullspd, double factor){
-        resetWheels();
         while(opModeIsActive() && (raw_offset == null || red_off < -threshold || red_off > threshold)){
             telemetry.addData("Path", "seeking skystone");
             calcOffset();
@@ -94,5 +97,28 @@ public abstract class VuforiaOp extends AutoOp {
             }
             telemetry.update();
         }
+    }
+    public void toSkystone(double threshold, double nullspd){
+        toSkystone(threshold, nullspd, 1000.0);
+    }
+    public void toSkystone(double threshold){
+        toSkystone(threshold, 0.1);
+    }
+    public void toSkystone(){
+        toSkystone(10.0);
+    }
+    
+    public void setCameraPosition(double horiz, double depth, double height){
+        // The following refers to "reference". This should probably be a point
+        // on the stationary plate of the claw.
+        // horiz: mm right of the reference.
+        // depth: mm behind the reference.
+        // height: mm above the reference.
+        cam_x = horiz;
+        cam_y = depth;
+        cam_z = height;
+        red_off -= cam_x;
+        blue_off -= cam_y;
+        green_off += cam_z;
     }
 }

--- a/VuforiaOp.java
+++ b/VuforiaOp.java
@@ -1,6 +1,7 @@
 package workspace;
 
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import org.firstinspires.ftc.robotcore.external.hardware.camera.WebcamName;
 import org.firstinspires.ftc.robotcore.external.matrices.VectorF;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import org.firstinspires.ftc.robotcore.external.navigation.VuforiaLocalizer;
@@ -36,7 +37,8 @@ public abstract class VuforiaOp extends AutoOp {
         int cameraMonitorViewId = hardwareMap.appContext.getResources().getIdentifier("cameraMonitorViewId", "id", hardwareMap.appContext.getPackageName());
         params = new VuforiaLocalizer.Parameters(cameraMonitorViewId);
         params.vuforiaLicenseKey = VUFORIA_KEY;
-        params.cameraName = hardwareMap.get(WebcamName.class, "Webcam1");
+        //params.cameraName = hardwareMap.get(WebcamName.class, "Webcam 1");
+        params.cameraDirection = VuforiaLocalizer.CameraDirection.BACK;
         localizer = ClassFactory.createVuforiaLocalizer(params);
         visionTargets = localizer.loadTrackablesFromAsset("Skystone");
         target = visionTargets.get(0);
@@ -56,11 +58,11 @@ public abstract class VuforiaOp extends AutoOp {
         visionTargets.activate();
     }
     
-    public OpenGLMatrix createMatrix(float x, float y, float z, float u, float v, float w){
+    /*public OpenGLMatrix createMatrix(float x, float y, float z, float u, float v, float w){
         return OpenGLMatrix.translation(x, y, z)
             .multiplied(Orientation.getRotationMatrix(
                 AxesReference.EXTRINSIC, AxesOrder.XYZ, AngleUnit.DEGREES, u, v, w));
-    }
+    }*/
     
     public void calcOffset(){
         OpenGLMatrix pose = listener.getPose();
@@ -78,6 +80,7 @@ public abstract class VuforiaOp extends AutoOp {
     }
     
     public void toSkystone(double threshold, double nullspd, double factor){
+        resetWheels();
         while(opModeIsActive() && (raw_offset == null || red_off < -threshold || red_off > threshold)){
             telemetry.addData("Path", "seeking skystone");
             calcOffset();

--- a/VuforiaOp.java
+++ b/VuforiaOp.java
@@ -1,6 +1,7 @@
 package workspace;
 
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import org.firstinspires.ftc.robotcore.external.matrices.VectorF;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import org.firstinspires.ftc.robotcore.external.navigation.VuforiaLocalizer;
 import org.firstinspires.ftc.robotcore.external.navigation.VuforiaTrackables;
@@ -24,8 +25,12 @@ public abstract class VuforiaOp extends AutoOp {
     
     protected OpenGLMatrix lastKnownLocation;
     protected OpenGLMatrix phoneLocation;
+    public double red_off;  // x; positive when skystone is right of the phone
+    public double blue_off;  // y; negative if skystone in viewig field
+    public double green_off;  // z; skystones should start on the ground.
+    public float[] raw_offset;  // green, red, blue; zxy
     
-    protected static final String VUFORIA_KEY = "";
+    protected static final String VUFORIA_KEY = "AeTCFCP/////AAABmfHb70GlwET4rTC9SGWFDMVfC6cZN+OykKIBJrcpYIVTGzbWZ11w8AoTq6mrdM68JbbKzA3C/+v46Jo8+pcraqzQ5QPOv23oHfxgDMKAlbxYGixALMMcSsE8Anv2NeBhMd+zLoRTYAnU8YQ7S35RYmeFRufFLUHF+Tkps1tZoWOxd6yyzuw10nwVVlZ1F4JhHVEHXoFsvUDXVxHENaFOxcy244tY+AM/qM4U9jD1RXLMPrp+ZLWmG/Bt8ja1avZHE0EWK5DKaKD0uWrT9A9WwT8w+aNjNxJKOdL9mq/fhZwDRPS6Q7flBwIQvVbq6bTXl4erMprFkPXo4yaZJvJo8ag+V5mEVe/cQ2N0A7qNtb3f";
     
     public void initVision(HardwareMap hardwareMap){
         int cameraMonitorViewId = hardwareMap.appContext.getResources().getIdentifier("cameraMonitorViewId", "id", hardwareMap.appContext.getPackageName());
@@ -36,11 +41,18 @@ public abstract class VuforiaOp extends AutoOp {
         visionTargets = localizer.loadTrackablesFromAsset("Skystone");
         target = visionTargets.get(0);
         target.setName("skystone");
-        target.setLocation(createMatrix(0, 0, 0, 0, 0, 0));
-        phoneLocation = createMatrix(0, 0, 0, 0, 0, 0);
+        //target.setLocation(createMatrix(0, 0, 0, 0, 0, 0));
+        //phoneLocation = createMatrix(0, 0, 0, 0, 0, 0);
         listener = (VuforiaTrackableDefaultListener) target.getListener();
-        listener.setPhoneInformation(phoneLocation, params.cameraDirection);
-        lastKnownLocation = createMatrix(0, 0, 0, 0, 0, 0);
+        //listener.setPhoneInformation(phoneLocation, params.cameraDirection);
+        //lastKnownLocation = createMatrix(0, 0, 0, 0, 0, 0);
+        green_off = 0;
+        red_off = 0;
+        blue_off = 0;
+        raw_offset = null;
+    }
+    
+    public void activateVision(){
         visionTargets.activate();
     }
     
@@ -50,9 +62,34 @@ public abstract class VuforiaOp extends AutoOp {
                 AxesReference.EXTRINSIC, AxesOrder.XYZ, AngleUnit.DEGREES, u, v, w));
     }
     
-    public float[] getOffset(){
-        OpenGLMatrix latestLocation = null;
-        float[] r = {0, 0};
-        return r;
+    public void calcOffset(){
+        OpenGLMatrix pose = listener.getPose();
+        if(pose == null){
+            raw_offset = null;
+            return;
+        }
+        VectorF trans = pose.getTranslation();
+        float[] off = {trans.get(0), trans.get(1), trans.get(2)};
+        // smooth the readings
+        green_off = 0.9*green_off + 0.1*off[0];
+        red_off = 0.9*red_off + 0.1*off[1];
+        blue_off = 0.9*blue_off + 0.1*off[2];
+        raw_offset = off;
+    }
+    
+    public void toSkystone(double threshold, double nullspd, double factor){
+        while(opModeIsActive() && (raw_offset == null || red_off < -threshold || red_off > threshold)){
+            telemetry.addData("Path", "seeking skystone");
+            calcOffset();
+            if(raw_offset == null){
+                strafeRightSpd(nullspd);
+                telemetry.addData("Skystone", "missing");
+            }
+            else{
+                strafeLeftSpd(red_off/factor);
+                telemetry.addData("Skystone", "%.0f", red_off);
+            }
+            telemetry.update();
+        }
     }
 }


### PR DESCRIPTION
# Autonomous
Improving the versatility, efficiency, and reliability autonomous is the primary focus of this pull request.
## Encoder-Based Movement
Added all encoder movement functions:
+ `forward_enc(tiles)`
+ `backward_enc(tiles)`
+ `strafeLeft_enc(tiles)`
+ `strafeRight_enc(tiles)`

These are accessible through the common interface as (respectively):
* `forward(tiles)`
* `backward(tiles)`
* `strafeLeft(tiles)`
* `strafeRight(tiles)`

The time-based movement methods are still accessible as:
+ `forward_time(tiles)`
+ `backward_time(tiles)`
+ `strafeLeft_time(tiles)`
+ `strafeRight_time(tiles)`

## Encoder-Based Position Sensing
The `getVector()` method was added, which returns a two-element array of doubles, where the first is the number of tiles moved forwards and the second is the number of tiles moved right. These measurements are totals since the last time the wheel encoders were reset. The `resetWheels()` method resets the encoders on all four wheels.

## Vector Movement
Also added vector movement, through the `move()` method. It takes three arguments, but is overloaded so the third is optional:
`y_tiles`: Number of tiles to move forward. Negative values move backward.
`x_tiles`: Number of tiles to move right. Negative values move left.
`name`: The name of the movement to display on the Driver Station. Defaults to `"Move"`.

## Organization
AutoOp was reorganized for readability and comment headers were added.

## Vuforia Skystone Detection
Vuforia back-end code was added in the VuforiaOp class, which extends AutoOp. A brief overview of the external interface follows:
`initVision()`: initializes Vuforia, and takes a `HardwareMap` as input to find the camera and phone.
`activateVision()`: begins scanning the field of view for skystones. This may be merged into `initVision()` in the future.
`calcOffset()`: calculates the offset of the nearest skystone to the robot. The offsets along each axis are currently stored as public fields in VuforiaOp. `red_off` is the horizontal offset, `blue_off` is the depth offset, and `green_off` is the vertical offset. These all default to the last known position, or 0 if that is not applicable. `raw_offset` is a three-element array storing the raw offsets returned by the last call to `calcOffset`, and is `null` if the object is not currently in view.
`toSkystone()`: Moves the robot until it is in front of a skystone. It is overloaded to have three option positional arguments, `threshold`, `nullspd`, and `factor`. The robot will continue moving until the absolute value of the horizontal offset of the skystone is below `threshold`. The robot will move at `nullspd`: speed to the left until a skystone is located, and then it will move with proportional to the distance to the skystone. Higher values of `factor` make the robot move more slowly.
`setCameraPosition()`: Sets the camera position. It takes three arguments: `horiz`, `depth`, and `height`, which are the x, y, and z offsets of the camera from the point on the robot that should be used as the reference.

## Vuforia Concept Test
A test program for the Vuforia back-end was added in the VisionTest class.

# Driver Control
Minor changes were made to driver control:

* Pressing X on the drive controller (`gamepad1`) now sets the fingers to stone-guiding mode (0.3 off of down) in Beans.
* Comment headers were added to Beans for readability